### PR TITLE
Update world dimensions after loading player

### DIFF
--- a/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
+++ b/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
@@ -184,6 +184,11 @@ public class VideoPlayerAndroid implements VideoPlayer, OnFrameAvailableListener
 						 new float[] {x, y, 0, 0, 1, x + width, y, 0, 1, 1, x + width, y + height, 0, 1, 0, x, y + height, 0, 0, 0});
 					 //@formatter:on
 
+					 // set viewport world dimensions according to video dimensions and viewport type
+					 viewport.setWorldSize(width, height);
+                	 cam.position.set(cam.viewportWidth / 2, cam.viewportHeight / 2, 0);
+                	 viewport.apply();
+
 					 prepared = true;
 					 if (sizeListener != null) {
 						  sizeListener.onVideoSize(width, height);

--- a/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
+++ b/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
@@ -186,8 +186,8 @@ public class VideoPlayerAndroid implements VideoPlayer, OnFrameAvailableListener
 
 					 // set viewport world dimensions according to video dimensions and viewport type
 					 viewport.setWorldSize(width, height);
-                	 cam.position.set(cam.viewportWidth / 2, cam.viewportHeight / 2, 0);
-                	 viewport.apply();
+					 cam.position.set(cam.viewportWidth / 2, cam.viewportHeight / 2, 0);
+					 viewport.apply();
 
 					 prepared = true;
 					 if (sizeListener != null) {


### PR DESCRIPTION
The current VideoPlayerAndroid does not adhere to the viewport type that was used in it's instantiation. The changes I've made updates the viewport world dimensions once the media player has been prepared and then update the viewport and camera to display the video in the correct dimensions.