### PR TITLE
Bug fix for viewport update and optimization

### DIFF
--- a/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
+++ b/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
@@ -186,7 +186,6 @@ public class VideoPlayerAndroid implements VideoPlayer, OnFrameAvailableListener
 
 					 // set viewport world dimensions according to video dimensions and viewport type
 					 viewport.setWorldSize(width, height);
-					 cam.position.set(cam.viewportWidth / 2, cam.viewportHeight / 2, 0);
 					 viewport.apply();
 
 					 prepared = true;

--- a/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
+++ b/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
@@ -186,7 +186,12 @@ public class VideoPlayerAndroid implements VideoPlayer, OnFrameAvailableListener
 
 					 // set viewport world dimensions according to video dimensions and viewport type
 					 viewport.setWorldSize(width, height);
-					 viewport.apply();
+					 Gdx.app.postRunnable(new Runnable() {
+						 @Override public void run() {
+							 // force viewport update to let scaling take effect
+							 viewport.update(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+						 }
+					 });
 
 					 prepared = true;
 					 if (sizeListener != null) {


### PR DESCRIPTION
I made two changes
* Removed a call to centre the video as the video is already centred when the mesh vertices was set.
* Forced a viewport update in order to let the viewport scaling (fit,fill etc..) take effect. The update method has direct opengl calls and requires the rendering thread to take effect. Simply calling viewport.apply would not be sufficient as the overloaded update method in the extended viewport (e.g. ScalingViewport) has to be called first.