### PR TITLE
Added method to get the current time.

### DIFF
--- a/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
+++ b/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
@@ -356,4 +356,9 @@ public class VideoPlayerAndroid implements VideoPlayer, OnFrameAvailableListener
 		  return player.isPlaying();
 	 }
 
+	 @Override
+	 public int getCurrentTimestamp () {
+		 return player.getCurrentPosition();
+	 }
+
 }

--- a/gdx-video-desktop/src/com/badlogic/gdx/video/VideoPlayerDesktop.java
+++ b/gdx-video-desktop/src/com/badlogic/gdx/video/VideoPlayerDesktop.java
@@ -302,7 +302,9 @@ public class VideoPlayerDesktop implements VideoPlayer {
 	 @Override public void pause () {
 		  if (!paused) {
 				paused = true;
-				audio.pause();
+				if (audio != null) {
+					audio.pause();
+				}
 				timeBeforePause = System.currentTimeMillis() - startTime;
 		  }
 	 }
@@ -310,7 +312,9 @@ public class VideoPlayerDesktop implements VideoPlayer {
 	 @Override public void resume () {
 		  if (paused) {
 				paused = false;
-				audio.play();
+				if (audio != null) {
+					audio.play();
+				}
 				startTime = System.currentTimeMillis() - timeBeforePause;
 		  }
 	 }

--- a/gdx-video-desktop/src/com/badlogic/gdx/video/VideoPlayerDesktop.java
+++ b/gdx-video-desktop/src/com/badlogic/gdx/video/VideoPlayerDesktop.java
@@ -221,11 +221,11 @@ public class VideoPlayerDesktop implements VideoPlayer {
 						  }
 						  texture = new Texture(image);
 					 } else {
+						  playing = false;
+						  renderTexture();
 						  if (completionListener != null) {
 								completionListener.onCompletionListener(currentFile);
 						  }
-						  playing = false;
-						  renderTexture();
 						  return false;
 					 }
 				}
@@ -239,8 +239,10 @@ public class VideoPlayerDesktop implements VideoPlayer {
 					 showAlreadyDecodedFrame = true;
 				}
 
-				renderTexture();
-
+		  }
+		  
+		  if (texture != null) {
+			  renderTexture();
 		  }
 		  return true;
 	 }

--- a/gdx-video-desktop/src/com/badlogic/gdx/video/VideoPlayerDesktop.java
+++ b/gdx-video-desktop/src/com/badlogic/gdx/video/VideoPlayerDesktop.java
@@ -342,4 +342,9 @@ public class VideoPlayerDesktop implements VideoPlayer {
 	 @Override public boolean isPlaying () {
 		  return playing;
 	 }
+
+	 @Override
+	 public int getCurrentTimestamp () {
+		  return (int)(decoder.getCurrentFrameTimestamp() * 1000);
+	 }
 }

--- a/gdx-video/src/com/badlogic/gdx/video/VideoPlayer.java
+++ b/gdx-video/src/com/badlogic/gdx/video/VideoPlayer.java
@@ -131,6 +131,13 @@ public interface VideoPlayer extends Disposable {
 	  * @return whether the video is still playing
 	  */
 	 boolean isPlaying ();
+	 
+	 /**
+	  * This will return the the time passed.
+	  * 
+	  * @return the time elapsed in milliseconds
+	  */
+	 int getCurrentTimestamp();
 
 	 /**
 	  * Disposes the VideoPlayer and ensures all buffers and resources are invalidated and disposed.

--- a/gdx-video/src/com/badlogic/gdx/video/VideoPlayerStub.java
+++ b/gdx-video/src/com/badlogic/gdx/video/VideoPlayerStub.java
@@ -63,6 +63,10 @@ class VideoPlayerStub implements VideoPlayer {
 	 @Override public boolean isPlaying () {
 		  return false;
 	 }
+	 
+	 @Override public int getCurrentTimestamp () {
+			return 0;
+	 }
 
 	 @Override public void dispose () {
 	 }


### PR DESCRIPTION
- All: Added method to get the current time in milliseconds.
- Desktop: Fixed null pointer crash when pausing/resuming with no audio.
- Desktop: Render the video texture even when paused.
