### PR TITLE
Instantiated shader in third constructor

### DIFF
--- a/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
+++ b/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
@@ -127,6 +127,8 @@ public class VideoPlayerAndroid implements VideoPlayer, OnFrameAvailableListener
 	 }
 
 	 public VideoPlayerAndroid (Camera cam, Mesh mesh, int primitiveType) {
+		  shader = new ShaderProgram(vertexShaderCode, fragmentShaderCode);
+		 
 		  this.cam = cam;
 		  this.mesh = mesh;
 		  this.primitiveType = primitiveType;


### PR DESCRIPTION
When you try to create a video player using a custom mesh in android you get a NullPointerException: Attempt to invoke virtual method 'void com.badlogic.gdx.graphics.glutils.ShaderProgram.begin()' on a null object reference. When I opened up VideoPlayerAndroid.java I noticed shader is never instantiated in the third constructor.