### PR TITLE
fix eclipse project names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,3 @@ subprojects {
         }
     }
 }
-
-tasks.eclipse.doLast {
-    delete ".project"
-}

--- a/gdx-video-android/build.gradle
+++ b/gdx-video-android/build.gradle
@@ -34,5 +34,5 @@ dependencies {
 }
 
 eclipse.project {
-    name = projectGroup + "-gdx-video-android"
+    name = projectGroup + "-android"
 }

--- a/gdx-video-desktop/build.gradle
+++ b/gdx-video-desktop/build.gradle
@@ -196,5 +196,5 @@ jnigen {
 }
 
 eclipse.project {
-    name = projectGroup + "-gdx-video-desktop"
+    name = projectGroup + "-desktop"
 }

--- a/gdx-video/build.gradle
+++ b/gdx-video/build.gradle
@@ -15,5 +15,5 @@ dependencies {
 }
 
 eclipse.project {
-    name = projectGroup + "-gdx-video-core"
+    name = projectGroup + "-core"
 }

--- a/test/android/build.gradle
+++ b/test/android/build.gradle
@@ -110,3 +110,7 @@ task run(type: Exec) {
 	def adb = path + "/platform-tools/adb"
 	commandLine "$adb", 'shell', 'am', 'start', '-n', 'com.badlogic.gdx.video.test/com.badlogic.gdx.video.test.android.AndroidLauncher'
 }
+
+eclipse.project {
+    name = appName + "-android"
+}

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -8,7 +8,7 @@ configure(subprojects - project(':test:android')) {
 
 subprojects {
 	version = '0.0.1-SNAPSHOT'
-	ext.appName = 'test'
+	ext.appName = 'gdx-video-test'
 	repositories {
 		mavenLocal()
 		mavenCentral()
@@ -18,9 +18,6 @@ subprojects {
 	}
 }
 
-// Clearing Eclipse project data in root folder:
-tasks.eclipse.doLast {
-	delete '.project'
-	delete '.classpath'
-	delete '.settings/'
+eclipse.project {
+    name = 'gdx-video-test'
 }


### PR DESCRIPTION
For people who use Eclipse ;-)

I had to rename appName for consistency : could mess with other projects with the same prefix.

I also removed Eclipse files deletion for some project, it's not necessary and mostly unwanted.

The fixed project layout is now : 
```
gdx-video
gdx-video-android
gdx-video-core
gdx-video-desktop
gdx-video-gwt
gdx-video-test
gdx-video-test-android
gdx-video-test-core
gdx-video-test-desktop
gdx-video-test-html
gdx-video-test-ios
gdx-video-test-lwjgl3
```