### PR TITLE
Avoid error when using GWT AssetFilter

### DIFF
--- a/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
+++ b/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
@@ -48,7 +48,7 @@ import java.io.IOException;
 
 /** Android implementation of the VideoPlayer class.
  *
- * @author Rob Bogie <rob.bogie@codepoke.net> */
+ * @author Rob Bogie &lt;rob.bogie@codepoke.net&gt; */
 public class VideoPlayerAndroid implements VideoPlayer, OnFrameAvailableListener {
 	//@off
 	String vertexShaderCode =

--- a/gdx-video-gwt/src/com/badlogic/gdx/video/VideoPlayerGwt.java
+++ b/gdx-video-gwt/src/com/badlogic/gdx/video/VideoPlayerGwt.java
@@ -37,14 +37,14 @@ public class VideoPlayerGwt implements VideoPlayer {
 	}
 
 	@Override
-	public boolean play (FileHandle file) throws FileNotFoundException {
-		if (!file.exists()) throw new FileNotFoundException();
+	public boolean play (FileHandle file) {
 		currentFile = file;
 		if (v != null) {
 			v.setSrc(((GwtFileHandle)file).getAssetUrl());
 			v.play();
+			return true;
 		}
-		return true;
+		return false;
 	}
 
 	@Override

--- a/test/core/src/main/java/com/badlogic/gdx/video/test/GdxVideoTest.java
+++ b/test/core/src/main/java/com/badlogic/gdx/video/test/GdxVideoTest.java
@@ -61,7 +61,7 @@ public class GdxVideoTest extends ApplicationAdapter {
 			try {
 				videoPlayer.play(Gdx.files.internal("libGDX - It's Good For You!.webm"));
 			} catch (FileNotFoundException e) {
-				System.out.println("Oh no!");
+				Gdx.app.error("gdx-video", "Oh no!");
 			}
 		}
 


### PR DESCRIPTION
Not sure why I didn't just open a pull request in the first place. Probably knew deep down how long it would take to test GWT changes. This ought to resolve #72.