### PR TITLE
Add setFilter function to configure the video's texture filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GDX-Video
 
-![GitHub Workflow Status (master)](https://img.shields.io/github/workflow/status/libgdx/gdx-video/Publish%20Snapshot/master?label=master)
+![GitHub Workflow Status (master)](https://img.shields.io/github/actions/workflow/status/libgdx/gdx-video/publish_snapshot.yml?branch=master)
 
 [![Sonatype Nexus (Releases)](https://img.shields.io/nexus/r/com.badlogicgames.gdx-video/gdx-video?nexusVersion=2&server=https%3A%2F%2Foss.sonatype.org&label=release)](https://search.maven.org/artifact/com.badlogicgames.gdx-video/gdx-video)
 [![Sonatype Nexus (Snapshots)](https://img.shields.io/nexus/s/com.badlogicgames.gdx-video/gdx-video?server=https%3A%2F%2Foss.sonatype.org&label=snapshot)](https://oss.sonatype.org/#nexus-search;gav~com.badlogicgames.gdx-video~gdx-video~~~~kw,versionexpand)

--- a/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
+++ b/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
@@ -49,7 +49,7 @@ import java.io.IOException;
 /** Android implementation of the VideoPlayer class.
  *
  * @author Rob Bogie &lt;rob.bogie@codepoke.net&gt; */
-public class VideoPlayerAndroid implements VideoPlayer, OnFrameAvailableListener {
+public class VideoPlayerAndroid extends AbstractVideoPlayer implements VideoPlayer, OnFrameAvailableListener {
 	//@off
 	String vertexShaderCode =
 			"#define highp\n" +
@@ -212,8 +212,11 @@ public class VideoPlayerAndroid implements VideoPlayer, OnFrameAvailableListener
 				frameAvailable = false;
 				videoTexture.updateTexImage();
 				if (renderToFbo) {
-					if (fbo == null)
+					if (fbo == null) {
 						fbo = new FrameBuffer(Pixmap.Format.RGB888, player.getVideoWidth(), player.getVideoHeight(), false);
+						frame = fbo.getColorBufferTexture();
+						frame.setFilter(minFilter, magFilter);
+					}
 					fbo.begin();
 					shader.bind();
 
@@ -231,7 +234,6 @@ public class VideoPlayerAndroid implements VideoPlayer, OnFrameAvailableListener
 					renderer.vertex(1, 1, 0);
 					renderer.end();
 					fbo.end();
-					frame = fbo.getColorBufferTexture();
 				}
 				return true;
 			}

--- a/gdx-video-desktop/src/com/badlogic/gdx/video/CommonVideoPlayerDesktop.java
+++ b/gdx-video-desktop/src/com/badlogic/gdx/video/CommonVideoPlayerDesktop.java
@@ -31,7 +31,7 @@ import com.badlogic.gdx.video.VideoDecoder.VideoDecoderBuffers;
 /** Desktop implementation of the VideoPlayer
  *
  * @author Rob Bogie rob.bogie@codepoke.net */
-abstract public class CommonVideoPlayerDesktop implements VideoPlayer {
+abstract public class CommonVideoPlayerDesktop extends AbstractVideoPlayer implements VideoPlayer {
 	VideoDecoder decoder;
 	Texture texture;
 	Music audio;
@@ -135,7 +135,10 @@ abstract public class CommonVideoPlayerDesktop implements VideoPlayer {
 			if (!showAlreadyDecodedFrame) {
 				ByteBuffer videoData = decoder.nextVideoFrame();
 				if (videoData != null) {
-					if (texture == null) texture = new Texture(getTextureWidth(), getTextureHeight(), Format.RGB888);
+					if (texture == null) {
+						texture = new Texture(getTextureWidth(), getTextureHeight(), Format.RGB888);
+						texture.setFilter(minFilter, magFilter);
+					}
 					texture.bind();
 					Gdx.gl.glTexImage2D(GL20.GL_TEXTURE_2D, 0, GL20.GL_RGB, getTextureWidth(), getTextureHeight(), 0, GL20.GL_RGB,
 						GL20.GL_UNSIGNED_BYTE, videoData);

--- a/gdx-video-gwt/src/com/badlogic/gdx/video/VideoPlayerGwt.java
+++ b/gdx-video-gwt/src/com/badlogic/gdx/video/VideoPlayerGwt.java
@@ -24,7 +24,7 @@ import com.badlogic.gdx.graphics.*;
 import com.badlogic.gdx.utils.Null;
 import com.google.gwt.media.client.Video;
 
-public class VideoPlayerGwt implements VideoPlayer {
+public class VideoPlayerGwt extends AbstractVideoPlayer implements VideoPlayer {
 	private FileHandle currentFile;
 	private final Video v = Video.createIfSupported();
 	private Texture frame;
@@ -59,7 +59,10 @@ public class VideoPlayerGwt implements VideoPlayer {
 					frame.dispose();
 					frame = null;
 				}
-				if (frame == null) frame = new Texture(width, height, Pixmap.Format.RGB888);
+				if (frame == null) {
+					frame = new Texture(width, height, Pixmap.Format.RGB888);
+					frame.setFilter(minFilter, magFilter);
+				}
 				frame.bind();
 				((GwtGL20)Gdx.gl).gl.texImage2D(GL20.GL_TEXTURE_2D, 0, GL20.GL_RGB, GL20.GL_RGB, GL20.GL_UNSIGNED_BYTE,
 					v.getVideoElement());

--- a/gdx-video-robovm/src/com/badlogic/gdx/video/VideoPlayerIos.java
+++ b/gdx-video-robovm/src/com/badlogic/gdx/video/VideoPlayerIos.java
@@ -57,7 +57,7 @@ import java.util.List;
 /** iOS implementation of the VideoPlayer class.
  *
  * @author Maximilian Wende &lt;dasisdormax@mailbox.org&gt; */
-public class VideoPlayerIos implements VideoPlayer {
+public class VideoPlayerIos extends AbstractVideoPlayer implements VideoPlayer {
 
 	protected FileHandle file;
 	protected AVAsset asset;
@@ -203,6 +203,7 @@ public class VideoPlayerIos implements VideoPlayer {
 		int texHeight = (int)(pixelBuffer.getDataSize() / bpr);
 		if (texture == null) {
 			texture = new Texture(texWidth, texHeight, Pixmap.Format.RGB888);
+			texture.setFilter(minFilter, magFilter);
 		}
 		texture.bind();
 		pixelBuffer.lockBaseAddress(CVPixelBufferLockFlags.ReadOnly);

--- a/gdx-video/src/com/badlogic/gdx/video/AbstractVideoPlayer.java
+++ b/gdx-video/src/com/badlogic/gdx/video/AbstractVideoPlayer.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright 2023 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.video;
+
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.Texture.TextureFilter;
+
+public abstract class AbstractVideoPlayer implements VideoPlayer {
+	protected TextureFilter minFilter = TextureFilter.Linear;
+	protected TextureFilter magFilter = TextureFilter.Linear;
+
+	@Override
+	public void setFilter (TextureFilter minFilter, TextureFilter magFilter) {
+		if (this.minFilter == minFilter && this.magFilter == magFilter) return;
+		this.minFilter = minFilter;
+		this.magFilter = magFilter;
+		Texture texture = getTexture();
+		if (texture == null) return;
+		texture.setFilter(minFilter, magFilter);
+	}
+}

--- a/gdx-video/src/com/badlogic/gdx/video/VideoPlayer.java
+++ b/gdx-video/src/com/badlogic/gdx/video/VideoPlayer.java
@@ -20,6 +20,7 @@ import java.io.FileNotFoundException;
 
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.utils.Disposable;
 import com.badlogic.gdx.utils.Null;
 
@@ -124,4 +125,8 @@ public interface VideoPlayer extends Disposable {
 	void setLooping (boolean looping);
 
 	boolean isLooping ();
+
+	/** This sets the texture filtering used for displaying the video on screen.
+	 * @see Texture#setFilter(TextureFilter minFilter, TextureFilter magFilter) */
+	void setFilter (TextureFilter minFilter, TextureFilter magFilter);
 }

--- a/gdx-video/src/com/badlogic/gdx/video/VideoPlayerStub.java
+++ b/gdx-video/src/com/badlogic/gdx/video/VideoPlayerStub.java
@@ -20,6 +20,7 @@ import java.io.FileNotFoundException;
 
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.utils.Null;
 
 class VideoPlayerStub implements VideoPlayer {
@@ -106,5 +107,10 @@ class VideoPlayerStub implements VideoPlayer {
 	@Override
 	public boolean isLooping () {
 		return false;
+	}
+
+	@Override
+	public void setFilter (TextureFilter minFilter, TextureFilter magFilter) {
+
 	}
 }


### PR DESCRIPTION
Adding to the previous discussion in #77, this is a simple implementation of configuring the texture filtering of a VideoPlayer. The filter is applied to the currently active video texture and all textures that are created later.

In order to share the implementation across platforms, an abstract class `AbstractVideoPlayer` was created. If a different way to do this is better or the name should be changed (I could also imagine "VideoPlayerCommon"), I am open to suggestions.

Finally, I updated the version number as there is now a default filter set that wasn't set before.