### PR TITLE
Android / iOS: Improve loading performance and reduce race conditions

### DIFF
--- a/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
+++ b/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
@@ -149,12 +149,7 @@ public class VideoPlayerAndroid extends AbstractVideoPlayer implements VideoPlay
 		});
 	}
 
-	@Override
-	public boolean play (final FileHandle file) throws FileNotFoundException {
-		if (!file.exists()) {
-			throw new FileNotFoundException("Could not find file: " + file.path());
-		}
-
+	private void playInternal (final FileHandle file) {
 		prepared = false;
 		frame = null;
 		stopped = false;
@@ -165,14 +160,10 @@ public class VideoPlayerAndroid extends AbstractVideoPlayer implements VideoPlay
 				@Override
 				public void run () {
 					if (stopped) return;
-					try {
-						play(file);
-					} catch (FileNotFoundException e) {
-						throw new RuntimeException(e);
-					}
+					playInternal(file);
 				}
 			});
-			return true;
+			return;
 		}
 
 		player.reset();
@@ -235,7 +226,15 @@ public class VideoPlayerAndroid extends AbstractVideoPlayer implements VideoPlay
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
+	}
 
+	@Override
+	public boolean play (FileHandle file) throws FileNotFoundException {
+		if (!file.exists()) {
+			throw new FileNotFoundException("Could not find file: " + file.path());
+		}
+
+		playInternal(file);
 		return true;
 	}
 

--- a/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
+++ b/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
@@ -255,7 +255,7 @@ public class VideoPlayerAndroid extends AbstractVideoPlayer implements VideoPlay
 		frameAvailable = false;
 		videoTexture.updateTexImage();
 
-		if(!renderToFbo) return true;
+		if (!renderToFbo) return true;
 
 		fbo.begin();
 		shader.bind();
@@ -300,6 +300,7 @@ public class VideoPlayerAndroid extends AbstractVideoPlayer implements VideoPlay
 	public void stop () {
 		if (player != null && player.isPlaying()) {
 			player.stop();
+			player.reset();
 		}
 		stopped = true;
 		prepared = false;
@@ -347,6 +348,7 @@ public class VideoPlayerAndroid extends AbstractVideoPlayer implements VideoPlay
 		}
 
 		if (fbo != null) fbo.dispose();
+		fbo = null;
 		frame = null;
 		if (renderer != null) {
 			renderer.dispose();

--- a/gdx-video/src/com/badlogic/gdx/video/VideoPlayer.java
+++ b/gdx-video/src/com/badlogic/gdx/video/VideoPlayer.java
@@ -72,18 +72,22 @@ public interface VideoPlayer extends Disposable {
 
 	/** This will set a listener for whenever the video size of a file is known (after calling play). This is needed since the size
 	 * of the video is not directly known after using the play method.
+	 * <p>
+	 * This may be called on any thread, so it is not safe to call other VideoPlayer functions directly.
 	 *
 	 * @param listener The listener to set */
 	void setOnVideoSizeListener (VideoSizeListener listener);
 
 	/** This will set a listener for when the video is done playing. The listener will be called every time a video is done
 	 * playing.
+	 * <p>
+	 * This may be called on any thread, so it is not safe to call other VideoPlayer functions directly.
 	 *
 	 * @param listener The listener to set */
 	void setOnCompletionListener (CompletionListener listener);
 
 	/** This will return the width of the currently playing video.
-	 *
+	 * <p>
 	 * This function cannot be called until the {@link VideoSizeListener} has been called for the currently playing video. If this
 	 * callback has not been set, a good alternative is to wait until the {@link #isBuffered} function returns true, which
 	 * guarantees the availability of the videoSize.
@@ -92,7 +96,7 @@ public interface VideoPlayer extends Disposable {
 	int getVideoWidth ();
 
 	/** This will return the height of the currently playing video.
-	 *
+	 * <p>
 	 * This function cannot be called until the {@link VideoSizeListener} has been called for the currently playing video. If this
 	 * callback has not been set, a good alternative is to wait until the {@link #isBuffered} function returns true, which
 	 * guarantees the availability of the videoSize.


### PR DESCRIPTION
### For Android ...

Work is now more clearly split between the Android Main thread and the libGDX Rendering thread. As a quick overview:

- The MediaPlayer is created and also released on the Android Main thread now
- The shader and textures are now created across multiple frames (using a simple 'setupStep' state machine).
- When calling `play()` before the MediaPlayer instance is created, the playback is queued for the next frame instead of blocking the render thread
- Make `frameAvailable` volatile, so we can get away without *synchronized* in `update`.

This improves the 'felt' performance (less noticeable stutters) when loading and playing video on some weaker devices I tested.

Maybe this is enough to fix #32

### For iOS ...

- Playback no longer waits for the preroll to finish (which doesn't reliably happen from testing)
- Instead, we wait for isReady AND the video resolution info to be loaded
- Some functions are set to synchronized, as restarting a finished (looping) video may happen on any thread.

### In general ...

The changes work with the assumptions:
1. that public VideoPlayer functions are only called on the libGDX Rendering Thread. (I think we can make this assumption similar to the rest of the libGDX World)
2. that callbacks may run on any Thread. (I added this to the documentation of the `setListener` functions)