### PR TITLE
Desktop: Reintroduce streaming FFmpeg file reader

### DIFF
--- a/gdx-video-desktop/src/com/badlogic/gdx/video/VideoDecoder.java
+++ b/gdx-video-desktop/src/com/badlogic/gdx/video/VideoDecoder.java
@@ -28,6 +28,11 @@ public class VideoDecoder implements Disposable {
 	 * object is a wrapper. */
 	private long nativePointer;
 
+	interface VideoFileReader {
+		@SuppressWarnings("unused")
+		int fillBuffer (ByteBuffer buffer);
+	}
+
 	public static class VideoDecoderBuffers {
 		private final ByteBuffer videoBuffer;
 		private final ByteBuffer audioBuffer;
@@ -116,7 +121,53 @@ public class VideoDecoder implements Disposable {
 	 	#include <stdexcept>
 
 	 	JavaVM* jvm = NULL;
+	 	JavaVMAttachArgs attachArgs;
 
+	 	struct FfMpegCustomFileReaderData {
+            jobject objectToCall;
+            jmethodID methodToCall;
+        };
+
+		static int ffmpegCustomFileReader(void* data, u_int8_t* buffer, int bufferSize) {
+			FfMpegCustomFileReaderData* customData = (FfMpegCustomFileReaderData*)data;
+			JNIEnv * env;
+			// double check it's all ok
+			int getEnvStat = jvm->GetEnv((void **)&env, JNI_VERSION_1_6);
+			if (getEnvStat == JNI_EDETACHED) {
+				if (jvm->AttachCurrentThread((void **) &env, (void *)&attachArgs) != 0) {
+					logError("Failed to attach\n");
+					return 0;
+				}
+			} else if (getEnvStat == JNI_EVERSION) {
+				logError("Unsupported version\n");
+				return 0;
+			}
+			jint bytes = env->CallIntMethod(customData->objectToCall, customData->methodToCall, env->NewDirectByteBuffer(buffer, bufferSize));
+			if (env->ExceptionCheck()) {
+				env->ExceptionDescribe();
+			}
+			if(getEnvStat == JNI_EDETACHED)
+				jvm->DetachCurrentThread();
+			if(bytes != bufferSize)
+				logDebug("Filled AVIO buffer partially (%d/%d bytes).\n", bytes, bufferSize);
+			return bytes;
+		}
+
+		static void customReaderDataCleanup(void* data) {
+			FfMpegCustomFileReaderData* customData = (FfMpegCustomFileReaderData*)data;
+			JNIEnv * env;
+			int getEnvStat = jvm->GetEnv((void **)&env, JNI_VERSION_1_6);
+			if (getEnvStat == JNI_EDETACHED) {
+				if (jvm->AttachCurrentThread((void **) &env, (void *)&attachArgs) != 0) {
+					logError("Failed to attach\n");
+					return;
+				}
+			}
+			env->DeleteGlobalRef(customData->objectToCall);
+			if(getEnvStat == JNI_EDETACHED)
+				jvm->DetachCurrentThread();
+            memset(customData, 0, sizeof(FfMpegCustomFileReaderData));
+		}
 	 */
 
 	/** Creates an instance on the native side.
@@ -128,25 +179,37 @@ public class VideoDecoder implements Disposable {
             env->GetJavaVM(&jvm);
         }
 
+        attachArgs.version = JNI_VERSION_1_6;
+		attachArgs.name = (char *)"FFMpegInternalThread";
+		attachArgs.group = NULL;
+
 		VideoDecoder* pointer = new VideoDecoder();
 		return (jlong)pointer;
 											 */
 
-	/** This will load a file for playback
+	/** This will load a video for playback from an I/O Stream
 	 *
-	 * @param filePath The path to the file containing the video data.
+	 * @param reader A VideoFileReader that is used to fill the FFmpeg IO buffers.
 	 * @return A VideoDecoderBuffers object which contains all the information that may be needed about the video.
 	 * @throws IllegalArgumentException When the filename is invalid.
 	 * @throws Exception                Runtime exceptions in c++, which can have different causes.
 	 */
-	public native VideoDecoderBuffers loadFile (String filePath)
+	public native VideoDecoderBuffers loadStream (VideoFileReader reader)
 			throws IllegalArgumentException, Exception;/*
 		VideoDecoder* pointer = getClassPointer<VideoDecoder>(env, object);
 		try {
 			VideoBufferInfo bufferInfo;
             memset(&bufferInfo, 0, sizeof(VideoBufferInfo));
-
-            pointer->loadFile(filePath, &bufferInfo);
+            FfMpegCustomFileReaderData* data = new FfMpegCustomFileReaderData();
+            memset(data, 0, sizeof(FfMpegCustomFileReaderData));
+            data->objectToCall = env->NewGlobalRef(reader);
+            jclass clazz = env->GetObjectClass(data->objectToCall);
+            data->methodToCall = env->GetMethodID(clazz, "fillBuffer", "(Ljava/nio/ByteBuffer;)I");
+            if(data->methodToCall == NULL) {
+                delete data;
+                throw std::invalid_argument("Supplied method name invalid! Is it having the correct signature?");
+            }
+            pointer->loadStream(ffmpegCustomFileReader, data, customReaderDataCleanup, &bufferInfo);
             jobject videoBuffer = NULL;
             jobject audioBuffer = NULL;
             if(bufferInfo.videoBuffer != NULL && bufferInfo.videoBufferSize > 0) {
@@ -218,4 +281,8 @@ public class VideoDecoder implements Disposable {
 		VideoDecoder* pointer = getClassPointer<VideoDecoder>(env, object);
 		return pointer->isBuffered();
 													 */
+
+	public static native void setDebug(boolean enableDebug);/*
+		debug(enableDebug);
+		*/
 }


### PR DESCRIPTION
This brings back the streaming file reader from GDX-Video versions before August 2023.

PR #77 changed the desktop implementation, so the provided file is opened directly by the FFmpeg library. I don't know exactly why, but apparently there are cases where this does not work (FFmpeg can't open the file even though the libGDX FileHandle exists).
This probably fixes #79.

The previous code was slightly tweaked to ensure proper cleanup and avoid some possible performance issues.

Was tested to work on MacOS ARM64, Linux x86_64, Windows 11 x86_64. 