### PR TITLE
Desktop: Preserve volume when looping

### DIFF
--- a/gdx-video-desktop/src/com/badlogic/gdx/video/CommonVideoPlayerDesktop.java
+++ b/gdx-video-desktop/src/com/badlogic/gdx/video/CommonVideoPlayerDesktop.java
@@ -179,7 +179,9 @@ abstract public class CommonVideoPlayerDesktop extends AbstractVideoPlayer imple
 				} else if (looping) {
 					try {
 						// NOTE: this just creates a new decoder instead of reusing the existing one.
+						float volume = getVolume();
 						play(currentFile);
+						setVolume(volume);
 					} catch (FileNotFoundException e) {
 						throw new RuntimeException(e);
 					}


### PR DESCRIPTION
Without this change, volume resets to 1 on loop. Would be nice if we could set the volume before commencing playback, but it doesn't seem to matter in practice.

`Music` doesn't provide a means of getting the pan, but gdx-video doesn't let the user set the pan so that's not a problem.