### PR TITLE
Desktop: Synchronise video to audio

### DIFF
--- a/gdx-video-desktop/src/com/badlogic/gdx/video/CommonVideoPlayerDesktop.java
+++ b/gdx-video-desktop/src/com/badlogic/gdx/video/CommonVideoPlayerDesktop.java
@@ -194,17 +194,17 @@ abstract public class CommonVideoPlayerDesktop extends AbstractVideoPlayer imple
 			}
 
 			isFirstFrame = false;
-			double millisecondsAhead;
+			double secondsAhead;
 			if (audio == null) {
 				float deltaTime = Gdx.graphics.getDeltaTime();
 				// Avoid huge delta time if game execution has been suspended
 				if (deltaTime >= 1f) deltaTime = 1f / Gdx.graphics.getDisplayMode().refreshRate;
 				currentVideoTime += deltaTime;
-				millisecondsAhead = decoder.getCurrentFrameTimestamp() - currentVideoTime;
+				secondsAhead = decoder.getCurrentFrameTimestamp() - currentVideoTime;
 			} else {
-				millisecondsAhead = decoder.getCurrentFrameTimestamp() - audio.getPosition();
+				secondsAhead = decoder.getCurrentFrameTimestamp() - audio.getPosition();
 			}
-			showAlreadyDecodedFrame = millisecondsAhead > .02f;
+			showAlreadyDecodedFrame = secondsAhead > .02f;
 			return newFrame;
 		}
 		return false;

--- a/gdx-video-desktop/src/com/badlogic/gdx/video/CommonVideoPlayerDesktop.java
+++ b/gdx-video-desktop/src/com/badlogic/gdx/video/CommonVideoPlayerDesktop.java
@@ -152,12 +152,8 @@ abstract public class CommonVideoPlayerDesktop extends AbstractVideoPlayer imple
 	@Override
 	public boolean update () {
 		if (decoder != null && (!paused || isFirstFrame) && playing) {
-			if (!paused && currentVideoTime == 0) {
-				// Since startTime is 0, this means that we should now display the first frame of the video, and set the
-				// time.
-				if (audio != null) {
-					audio.play();
-				}
+			if (!paused && audio != null) {
+				audio.play();
 			}
 
 			boolean newFrame = false;


### PR DESCRIPTION
On Windows, when the game is dragged for a few seconds, the audio pauses. That's just how libGDX is, nothing to do with gdx-video specifically. But the result of that is the `System.currentTimeMillis()` calculation falls out of sync.

I've tried to improve the situation here, but I'm unsure how robust it is. It will invariably get tested while I develop my game.

Note: This does not do anything to fix the fact gdx-video isn't very good at keeping up. E.g. if a 60fps video is played on a 50Hz monitor, video playback will still fall behind if the video is only updated once per frame. I think that's best tackled separately.