### PR TITLE
Desktop: Add null checks to volume

### DIFF
--- a/gdx-video-desktop/gdx-video-lwjgl3/src/com/badlogic/gdx/video/VideoPlayerDesktop.java
+++ b/gdx-video-desktop/gdx-video-lwjgl3/src/com/badlogic/gdx/video/VideoPlayerDesktop.java
@@ -16,13 +16,16 @@
 
 package com.badlogic.gdx.video;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.audio.Music;
+import com.badlogic.gdx.backends.lwjgl3.audio.mock.MockAudio;
 
 import java.nio.ByteBuffer;
 
 public class VideoPlayerDesktop extends CommonVideoPlayerDesktop {
 	@Override
 	Music createMusic (VideoDecoder decoder, ByteBuffer audioBuffer, int audioChannels, int sampleRate) {
+		if (Gdx.audio.getClass() == MockAudio.class) return null;
 		return new RawMusic(decoder, audioBuffer, audioChannels, sampleRate);
 	}
 }

--- a/gdx-video-desktop/src/com/badlogic/gdx/video/CommonVideoPlayerDesktop.java
+++ b/gdx-video-desktop/src/com/badlogic/gdx/video/CommonVideoPlayerDesktop.java
@@ -310,12 +310,12 @@ abstract public class CommonVideoPlayerDesktop extends AbstractVideoPlayer imple
 
 	@Override
 	public void setVolume (float volume) {
-		audio.setVolume(volume);
+		if (audio != null) audio.setVolume(volume);
 	}
 
 	@Override
 	public float getVolume () {
-		return audio.getVolume();
+		return audio == null ? 0 : audio.getVolume();
 	}
 
 	@Override

--- a/gdx-video-desktop/src/com/badlogic/gdx/video/CommonVideoPlayerDesktop.java
+++ b/gdx-video-desktop/src/com/badlogic/gdx/video/CommonVideoPlayerDesktop.java
@@ -315,7 +315,8 @@ abstract public class CommonVideoPlayerDesktop extends AbstractVideoPlayer imple
 
 	@Override
 	public float getVolume () {
-		return audio == null ? 0 : audio.getVolume();
+		if (audio == null) return 0;
+		return audio.getVolume();
 	}
 
 	@Override


### PR DESCRIPTION
This should now be safe to use with `config.disableAudio(true)` like libGDX itself.

80a3a31 - \*without