### PR TITLE
Do not create iOS video player if the OS version is < 15

### DIFF
--- a/gdx-video/src/com/badlogic/gdx/video/VideoPlayerCreator.java
+++ b/gdx-video/src/com/badlogic/gdx/video/VideoPlayerCreator.java
@@ -58,7 +58,11 @@ public class VideoPlayerCreator {
 				Gdx.app.log("Gdx-Video", "VideoPlayer can't be used on android < API level 12");
 			}
 		} else if (type == ApplicationType.iOS) {
-			className = "com.badlogic.gdx.video.VideoPlayerIos";
+			if (Gdx.app.getVersion >= 15) {
+				className = "com.badlogic.gdx.video.VideoPlayerIos";
+			} else {
+				Gdx.app.log("Gdx-Video", "VideoPlayer can't be used on iOS < 15");
+			}
 		} else if (type == ApplicationType.Desktop) {
 			className = "com.badlogic.gdx.video.VideoPlayerDesktop";
 		} else if (type == ApplicationType.WebGL) {

--- a/gdx-video/src/com/badlogic/gdx/video/VideoPlayerCreator.java
+++ b/gdx-video/src/com/badlogic/gdx/video/VideoPlayerCreator.java
@@ -58,7 +58,7 @@ public class VideoPlayerCreator {
 				Gdx.app.log("Gdx-Video", "VideoPlayer can't be used on android < API level 12");
 			}
 		} else if (type == ApplicationType.iOS) {
-			if (Gdx.app.getVersion >= 15) {
+			if (Gdx.app.getVersion() >= 15) {
 				className = "com.badlogic.gdx.video.VideoPlayerIos";
 			} else {
 				Gdx.app.log("Gdx-Video", "VideoPlayer can't be used on iOS < 15");


### PR DESCRIPTION
The VideoPlayerIos implementation relies on methods that are only available for iOS 15+.

For example: https://developer.apple.com/documentation/avfoundation/avfragmentedasset/3746534-loadtrackswithmediatype?language=objc