### PR TITLE
Update VideoActor to set the batch color before drawing the video texture

### DIFF
--- a/gdx-video/src/com/badlogic/gdx/video/VideoPlayer.java
+++ b/gdx-video/src/com/badlogic/gdx/video/VideoPlayer.java
@@ -19,7 +19,6 @@ package com.badlogic.gdx.video;
 import java.io.FileNotFoundException;
 
 import com.badlogic.gdx.files.FileHandle;
-import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.utils.Disposable;

--- a/gdx-video/src/com/badlogic/gdx/video/VideoPlayer.java
+++ b/gdx-video/src/com/badlogic/gdx/video/VideoPlayer.java
@@ -19,6 +19,7 @@ package com.badlogic.gdx.video;
 import java.io.FileNotFoundException;
 
 import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.utils.Disposable;

--- a/gdx-video/src/com/badlogic/gdx/video/scenes/scene2d/VideoActor.java
+++ b/gdx-video/src/com/badlogic/gdx/video/scenes/scene2d/VideoActor.java
@@ -49,6 +49,8 @@ public class VideoActor extends Actor {
 	public void draw (Batch batch, float parentAlpha) {
 		Texture texture = player.getTexture();
 		if (texture == null) return;
+		Color color = getColor();
+		batch.setColor(color.r, color.g, color.b, color.a * parentAlpha);
 		batch.draw(texture, getX(), getY(), getWidth(), getHeight(), 0, 0, player.getVideoWidth(), player.getVideoHeight(), false,
 			false);
 	}

--- a/gdx-video/src/com/badlogic/gdx/video/scenes/scene2d/VideoActor.java
+++ b/gdx-video/src/com/badlogic/gdx/video/scenes/scene2d/VideoActor.java
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.video.scenes.scene2d;
 
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.scenes.scene2d.Actor;


### PR DESCRIPTION
Setting the batch color before drawing the video texture prevents other actors in the stage that modifies the batch color from tinting the video texture.