### PR TITLE
Add null checks to VideoPlayerIos

### DIFF
--- a/gdx-video-robovm/src/com/badlogic/gdx/video/VideoPlayerIos.java
+++ b/gdx-video-robovm/src/com/badlogic/gdx/video/VideoPlayerIos.java
@@ -161,6 +161,9 @@ public class VideoPlayerIos extends AbstractVideoPlayer implements VideoPlayer {
 		asset.loadTracksWithMediaType(AVMediaType.Video.toString(), new VoidBlock2<NSArray<?>, NSError>() {
 			@Override
 			public void invoke (NSArray<?> nsObjects, NSError nsError) {
+				if (nsObjects == null) {
+					return;
+				}
 				for (NSObject obj : nsObjects) {
 					AVAssetTrack track = obj.as(AVAssetTrack.class);
 					onVideoTrackLoaded(track);
@@ -171,6 +174,9 @@ public class VideoPlayerIos extends AbstractVideoPlayer implements VideoPlayer {
 		asset.loadTracksWithMediaType(AVMediaType.Audio.toString(), new VoidBlock2<NSArray<?>, NSError>() {
 			@Override
 			public void invoke (NSArray<?> nsObjects, NSError nsError) {
+				if (nsObjects == null) {
+					return;
+				}
 				for (NSObject obj : nsObjects) {
 					AVAssetTrack track = obj.as(AVAssetTrack.class);
 					onAudioTrackLoaded(track);


### PR DESCRIPTION
According to the docs, loadTracksWithMediaType completionHandler tracks parameter may be null if an error occurs.

https://developer.apple.com/documentation/avfoundation/avfragmentedasset/loadtracks(withmediatype:completionhandler:)?changes=_8&language=objc

This also explains the crashes we are getting in our game:

```
          Crashed: com.apple.avfoundation.avasset.completionsQueue
0  IOSLauncher                    0x5ad1b0 [J]com.badlogic.gdx.video.VideoPlayerIos$3.invoke(Lorg/robovm/apple/foundation/NSArray;Lorg/robovm/apple/foundation/NSError;)V + 164 (VideoPlayerIos$3.java:164)
1  IOSLauncher                    0x5ad2b8 [J]com.badlogic.gdx.video.VideoPlayerIos$3.invoke(Ljava/lang/Object;Ljava/lang/Object;)V + 161 (VideoPlayerIos$3.java:161)
2  IOSLauncher                    0x5ad2b8 [J]com.badlogic.gdx.video.VideoPlayerIos$3.invoke(Ljava/lang/Object;Ljava/lang/Object;)V + 161 (VideoPlayerIos$3.java:161)
3  IOSLauncher                    0x176da7c [J]org.robovm.apple.avfoundation.AVAsset$$BlockMarshaler0.invoked(Lorg/robovm/objc/ObjCBlock;Lorg/robovm/apple/foundation/NSArray;Lorg/robovm/apple/foundation/NSError;)V + 4335639164
4  IOSLauncher                    0x176d7e8 [j]org.robovm.apple.avfoundation.AVAsset$$BlockMarshaler0.invoked(Lorg/robovm/objc/ObjCBlock;Lorg/robovm/apple/foundation/NSArray;Lorg/robovm/apple/foundation/NSError;)V[callback] + 4335638504
5  AVFCore                        0xc6f40 __AVLoadValuesAsynchronously_block_invoke + 392
6  libdispatch.dylib              0x2370 _dispatch_call_block_and_release + 32
7  libdispatch.dylib              0x40d0 _dispatch_client_callout + 20
8  libdispatch.dylib              0xb6d8 _dispatch_lane_serial_drain + 744
9  libdispatch.dylib              0xc214 _dispatch_lane_invoke + 432
10 libdispatch.dylib              0x17258 _dispatch_root_queue_drain_deferred_wlh + 288
11 libdispatch.dylib              0x16aa4 _dispatch_workloop_worker_thread + 540
12 libsystem_pthread.dylib        0x4c7c _pthread_wqthread + 288
13 libsystem_pthread.dylib        0x1488 start_wqthread + 8
```