### PR TITLE
Do not play on resume if the video is not loaded for CommonVideoPlayerDesktop

### DIFF
--- a/gdx-video-desktop/src/com/badlogic/gdx/video/CommonVideoPlayerDesktop.java
+++ b/gdx-video-desktop/src/com/badlogic/gdx/video/CommonVideoPlayerDesktop.java
@@ -297,7 +297,9 @@ abstract public class CommonVideoPlayerDesktop extends AbstractVideoPlayer {
 
 	@Override
 	public void resume () {
-		play();
+		if (decoder != null) {
+			play();
+		}
 	}
 
 	@Override


### PR DESCRIPTION
In the old implementation (where `load` & `play` were done together), `resume` would load and play the video.

This change avoids a `NullPointerException` if calling `resume` before `load`.