### PR TITLE
Fix black video on VideoPlayerAndroid when fbo size changes.

### DIFF
--- a/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
+++ b/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
@@ -279,7 +279,8 @@ public class VideoPlayerAndroid extends AbstractVideoPlayer implements VideoPlay
 		renderer.vertex(1, 1, 0);
 		renderer.end();
 		fbo.end();
-		if (frame == null) {
+
+		if (frame != fbo.getColorBufferTexture()) {
 			frame = fbo.getColorBufferTexture();
 			frame.setFilter(minFilter, magFilter);
 		}

--- a/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
+++ b/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
@@ -280,8 +280,9 @@ public class VideoPlayerAndroid extends AbstractVideoPlayer implements VideoPlay
 		renderer.end();
 		fbo.end();
 
-		if (frame != fbo.getColorBufferTexture()) {
-			frame = fbo.getColorBufferTexture();
+		Texture colorBufferTexture = fbo.getColorBufferTexture();
+		if (frame != colorBufferTexture) {
+			frame = colorBufferTexture;
 			frame.setFilter(minFilter, magFilter);
 		}
 

--- a/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
+++ b/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
@@ -108,6 +108,7 @@ public class VideoPlayerAndroid extends AbstractVideoPlayer implements VideoPlay
 	private SurfaceTexture videoTexture;
 	private Surface surface;
 	private FrameBuffer fbo;
+	private Texture frame;
 	private ImmediateModeRenderer20 renderer;
 
 	private MediaPlayer player;
@@ -148,6 +149,7 @@ public class VideoPlayerAndroid extends AbstractVideoPlayer implements VideoPlay
 
 	private void playInternal (final FileHandle file) {
 		prepared = false;
+		frame = null;
 		stopped = false;
 
 		// If we haven't finished loading the media player yet, wait without blocking.
@@ -180,11 +182,6 @@ public class VideoPlayerAndroid extends AbstractVideoPlayer implements VideoPlay
 						}
 						if (fbo == null) {
 							fbo = new FrameBuffer(Pixmap.Format.RGB888, player.getVideoWidth(), player.getVideoHeight(), false);
-							fbo.getColorBufferTexture().setFilter(minFilter, magFilter);
-							fbo.begin();
-							Gdx.gl.glClearColor(0, 0, 0, 1);
-							Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-							fbo.end();
 						}
 						prepared = true;
 						player.setVolume(currentVolume, currentVolume);
@@ -282,6 +279,10 @@ public class VideoPlayerAndroid extends AbstractVideoPlayer implements VideoPlay
 		renderer.vertex(1, 1, 0);
 		renderer.end();
 		fbo.end();
+		if (frame == null) {
+			frame = fbo.getColorBufferTexture();
+			frame.setFilter(minFilter, magFilter);
+		}
 
 		return true;
 	}
@@ -289,7 +290,7 @@ public class VideoPlayerAndroid extends AbstractVideoPlayer implements VideoPlay
 	@Override
 	@Null
 	public Texture getTexture () {
-		return fbo == null ? null : fbo.getColorBufferTexture();
+		return frame;
 	}
 
 	/** For android, this will return whether the prepareAsync method of the android MediaPlayer is done with preparing.
@@ -348,6 +349,7 @@ public class VideoPlayerAndroid extends AbstractVideoPlayer implements VideoPlay
 
 		if (fbo != null) fbo.dispose();
 		fbo = null;
+		frame = null;
 		if (renderer != null) {
 			renderer.dispose();
 			shader.dispose();

--- a/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
+++ b/gdx-video-android/src/com/badlogic/gdx/video/VideoPlayerAndroid.java
@@ -108,7 +108,6 @@ public class VideoPlayerAndroid extends AbstractVideoPlayer implements VideoPlay
 	private SurfaceTexture videoTexture;
 	private Surface surface;
 	private FrameBuffer fbo;
-	private Texture frame;
 	private ImmediateModeRenderer20 renderer;
 
 	private MediaPlayer player;
@@ -149,7 +148,6 @@ public class VideoPlayerAndroid extends AbstractVideoPlayer implements VideoPlay
 
 	private void playInternal (final FileHandle file) {
 		prepared = false;
-		frame = null;
 		stopped = false;
 
 		// If we haven't finished loading the media player yet, wait without blocking.
@@ -182,6 +180,11 @@ public class VideoPlayerAndroid extends AbstractVideoPlayer implements VideoPlay
 						}
 						if (fbo == null) {
 							fbo = new FrameBuffer(Pixmap.Format.RGB888, player.getVideoWidth(), player.getVideoHeight(), false);
+							fbo.getColorBufferTexture().setFilter(minFilter, magFilter);
+							fbo.begin();
+							Gdx.gl.glClearColor(0, 0, 0, 1);
+							Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+							fbo.end();
 						}
 						prepared = true;
 						player.setVolume(currentVolume, currentVolume);
@@ -279,10 +282,6 @@ public class VideoPlayerAndroid extends AbstractVideoPlayer implements VideoPlay
 		renderer.vertex(1, 1, 0);
 		renderer.end();
 		fbo.end();
-		if (frame == null) {
-			frame = fbo.getColorBufferTexture();
-			frame.setFilter(minFilter, magFilter);
-		}
 
 		return true;
 	}
@@ -290,7 +289,7 @@ public class VideoPlayerAndroid extends AbstractVideoPlayer implements VideoPlay
 	@Override
 	@Null
 	public Texture getTexture () {
-		return frame;
+		return fbo == null ? null : fbo.getColorBufferTexture();
 	}
 
 	/** For android, this will return whether the prepareAsync method of the android MediaPlayer is done with preparing.
@@ -349,7 +348,6 @@ public class VideoPlayerAndroid extends AbstractVideoPlayer implements VideoPlay
 
 		if (fbo != null) fbo.dispose();
 		fbo = null;
-		frame = null;
 		if (renderer != null) {
 			renderer.dispose();
 			shader.dispose();


### PR DESCRIPTION
When a video is played and the `fbo` size changes, `fbo` is recreated.

The field `frame` is set to null and after the first `update()` call, it is initialized with the `fbo` texture.

If `update` is called before `fbo` is re-initialized, `frame` will get the old `fbo` texture and it will result into a black screen video.

**Proposed approach:**

Check the `frame` against the current `fbo` texture instead of just checking if it is null.

**First approach I had:**

Remove the `frame` field, because we can get the texture directly from `fbo` and thus fixes the issue (and makes the code less brittle because we don't need to keep updating the `frame` field anymore). This solution has a caveat that until the first frame is available, the rendered texture will be black.